### PR TITLE
feat: Assertions are required to have the correct function signature

### DIFF
--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -74,6 +74,10 @@ pub trait TestFunctionExt {
     fn tfe_as_str(&self) -> &str;
     #[doc(hidden)]
     fn tfe_has_inputs(&self) -> bool;
+    #[doc(hidden)]
+    fn tfe_is_valid_assertion_signature(&self) -> bool;
+    #[doc(hidden)]
+    fn tfe_is_from_string(&self) -> bool;
 }
 
 impl TestFunctionExt for Function {
@@ -83,6 +87,17 @@ impl TestFunctionExt for Function {
 
     fn tfe_has_inputs(&self) -> bool {
         !self.inputs.is_empty()
+    }
+
+    fn tfe_is_valid_assertion_signature(&self) -> bool {
+        self.inputs.is_empty()
+        && self.outputs.len() == 1
+        && self.outputs.iter().all(|output| 
+            output.ty.eq("bool"))
+    }
+
+    fn tfe_is_from_string(&self) -> bool {
+        false
     }
 }
 
@@ -94,6 +109,14 @@ impl TestFunctionExt for String {
     fn tfe_has_inputs(&self) -> bool {
         false
     }
+
+    fn tfe_is_valid_assertion_signature(&self) -> bool {
+        false
+    }
+
+    fn tfe_is_from_string(&self) -> bool {
+        true
+    }
 }
 
 impl TestFunctionExt for str {
@@ -101,8 +124,16 @@ impl TestFunctionExt for str {
         self
     }
 
+    fn tfe_is_valid_assertion_signature(&self) -> bool {
+        false
+    }
+
     fn tfe_has_inputs(&self) -> bool {
         false
+    }
+
+    fn tfe_is_from_string(&self) -> bool {
+        true
     }
 }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -394,7 +394,7 @@ impl MultiContractRunnerBuilder {
 
             // if it's a test, link it and add to deployable contracts
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
-                abi.functions().any(|func| func.name.is_any_test())
+                abi.functions().any(|func| func.is_any_test())
             {
                 let Some(bytecode) =
                     contract.get_bytecode_bytes().map(|b| b.into_owned()).filter(|b| !b.is_empty())

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -451,7 +451,7 @@ impl TestResult {
         }
     }
 
-    /// Returns the skipped result for single test (used in skipped fuzz and assertion tests too).
+    /// Returns the skipped result for single test (used in skipped fuzz and alert tests too).
     pub fn single_skip(mut self) -> Self {
         self.status = TestStatus::Skipped;
         self.decoded_logs = decode_console_logs(&self.logs);
@@ -497,14 +497,14 @@ impl TestResult {
 
     /// Returns the result for single test. Merges execution results (logs, labeled addresses,
     /// traces and coverages) in initial setup results.
-    pub fn assertion_result(
+    pub fn alert_result(
         mut self,
         success: bool,
         reason: Option<String>,
         raw_call_result: RawCallResult,
     ) -> Self {
         self.kind =
-            TestKind::Assertion { gas: raw_call_result.gas_used.wrapping_sub(raw_call_result.stipend) };
+            TestKind::Alert { gas: raw_call_result.gas_used.wrapping_sub(raw_call_result.stipend) };
 
         // Record logs, labels, traces and merge coverages.
         self.logs.extend(raw_call_result.logs);
@@ -521,8 +521,8 @@ impl TestResult {
         self
     }
 
-    /// Returns the failed result with reason for an assertion.
-    pub fn assertion_fail(mut self, err: EvmError) -> Self {
+    /// Returns the failed result with reason for an alert test.
+    pub fn alert_fail(mut self, err: EvmError) -> Self {
         self.status = TestStatus::Failure;
         self.reason = Some(err.to_string());
         self
@@ -641,7 +641,7 @@ impl TestResult {
 /// Data report by a test.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TestKindReport {
-    Assertion { gas: u64 },
+    Alert { gas: u64 },
     Unit { gas: u64 },
     Fuzz { runs: usize, mean_gas: u64, median_gas: u64 },
     Invariant { runs: usize, calls: usize, reverts: usize },
@@ -653,7 +653,7 @@ impl fmt::Display for TestKindReport {
             Self::Unit { gas } => {
                 write!(f, "(gas: {gas})")
             }
-            Self::Assertion { gas } => {
+            Self::Alert { gas } => {
                 write!(f, "(gas: {gas})")
             }
             Self::Fuzz { runs, mean_gas, median_gas } => {
@@ -671,7 +671,7 @@ impl TestKindReport {
     pub fn gas(&self) -> u64 {
         match *self {
             Self::Unit { gas } => gas,
-            Self::Assertion { gas } => gas,
+            Self::Alert { gas } => gas,
             // We use the median for comparisons
             Self::Fuzz { median_gas, .. } => median_gas,
             // We return 0 since it's not applicable
@@ -683,8 +683,8 @@ impl TestKindReport {
 /// Various types of tests
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TestKind {
-    /// An assertion test result.
-    Assertion { 
+    /// An alert test result.
+    Alert { 
         gas: u64,
     },
     /// A unit test.
@@ -711,7 +711,7 @@ impl TestKind {
     /// The gas consumed by this test
     pub fn report(&self) -> TestKindReport {
         match *self {
-            Self::Assertion { gas } => TestKindReport::Unit { gas },
+            Self::Alert { gas } => TestKindReport::Unit { gas },
             Self::Unit { gas } => TestKindReport::Unit { gas },
             Self::Fuzz { first_case: _, runs, mean_gas, median_gas } => {
                 TestKindReport::Fuzz { runs, mean_gas, median_gas }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -397,8 +397,8 @@ impl<'a> ContractRunner<'a> {
                             identified_contracts.as_ref().unwrap(),
                         )
                     }
-                    TestFunctionKind::Assertion => {
-                        self.run_assertion(func, setup)
+                    TestFunctionKind::Alert => {
+                        self.run_alert(func, setup)
                     }
                     _ => unreachable!()
                 };
@@ -448,13 +448,13 @@ impl<'a> ContractRunner<'a> {
         test_result.single_result(success, reason, raw_call_result)
     }
 
-    /// Runs a single assertion.
+    /// Runs a single alert test.
     ///
     /// Calls the given functions and returns the `TestResult`.
     ///
     /// State modifications are not committed to the evm database but discarded after the call,
     /// similar to `eth_call`.
-    pub fn run_assertion(
+    pub fn run_alert(
         &self,
         func: &Function,
         setup: TestSetup,
@@ -462,7 +462,7 @@ impl<'a> ContractRunner<'a> {
         let address = setup.address;
         let test_result = TestResult::new(setup);
 
-        // Run assertion test
+        // Run alert test
         let (mut raw_call_result, reason) = match self.executor.call(
             self.sender,
             address,
@@ -474,12 +474,12 @@ impl<'a> ContractRunner<'a> {
             Ok(res) => (res.raw, None),
             Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
             Err(EvmError::SkipError) => return test_result.single_skip(),
-            Err(err) => return test_result.assertion_fail(err),
+            Err(err) => return test_result.alert_fail(err),
         };
 
         let success = 
             self.executor.is_raw_call_mut_success(address, &mut raw_call_result, false);
-        test_result.assertion_result(success, reason, raw_call_result)
+        test_result.alert_result(success, reason, raw_call_result)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -211,7 +211,7 @@ impl<'a> ContractRunner<'a> {
     /// current test.
     fn fuzz_fixtures(&mut self, address: Address) -> FuzzFixtures {
         let mut fixtures = HashMap::new();
-        let fixture_functions = self.contract.abi.functions().filter(|func| func.is_fixture());
+        let fixture_functions = self.contract.abi.functions().filter(|func| func.name.is_fixture());
         for func in fixture_functions {
             if func.inputs.is_empty() {
                 // Read fixtures declared as functions.
@@ -308,7 +308,7 @@ impl<'a> ContractRunner<'a> {
         });
 
         // Invariant testing requires tracing to figure out what contracts were created.
-        let has_invariants = self.contract.abi.functions().any(|func| func.is_invariant_test());
+        let has_invariants = self.contract.abi.functions().any(|func| func.name.is_invariant_test());
         let tmp_tracing =
             self.executor.inspector().tracer.is_none() && has_invariants && call_setup;
         if tmp_tracing {
@@ -400,7 +400,7 @@ impl<'a> ContractRunner<'a> {
                     TestFunctionKind::Assertion => {
                         self.run_assertion(func, setup)
                     }
-                    _ => unreachable!(),
+                    _ => unreachable!()
                 };
 
                 res.duration = start.elapsed();


### PR DESCRIPTION
This change adds validation that assertion functions in Solidity adhere to the function signature defined by the Monitor PRD.

This change was tested manually.

## Motivation

## Solution