### PR TITLE
feat: Ensure assertion return values can be interpreted

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -5,8 +5,9 @@ use crate::{
     fuzz::{BaseCounterExample, FuzzedCases},
     gas_report::GasReport,
 };
-use alloy_primitives::{Address, Log};
+use alloy_primitives::{Address, Log, U256};
 use eyre::Report;
+use forge_fmt::solang_ext::AstEq;
 use foundry_common::{evm::Breakpoints, get_contract_name, get_file_name, shell};
 use foundry_evm::{
     coverage::HitMaps,
@@ -17,9 +18,7 @@ use foundry_evm::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap},
-    fmt::{self, Write},
-    time::Duration,
+    collections::{BTreeMap, HashMap}, fmt::{self, Write}, io::Read, time::Duration, u128
 };
 use yansi::Paint;
 
@@ -503,8 +502,28 @@ impl TestResult {
         reason: Option<String>,
         raw_call_result: RawCallResult,
     ) -> Self {
+        let outcome_kind = if let Some(output) = raw_call_result.out {
+            let bytes = output.into_data();
+            match U256::try_from_be_slice(&bytes as &[u8]) {
+                None => {
+                    AssertionOutcomeKind::UnknownReturn
+                },
+                Some(val) => {
+                    if val.leading_zeros() == 255 {
+                        AssertionOutcomeKind::Success
+                    } else if val.is_zero() {
+                        AssertionOutcomeKind::Failure
+                    } else {
+                        AssertionOutcomeKind::UnknownReturn
+                    }
+                }
+            }
+        } else {
+            AssertionOutcomeKind::UnknownReturn
+        };
+
         self.kind =
-            TestKind::Alert { gas: raw_call_result.gas_used.wrapping_sub(raw_call_result.stipend) };
+            TestKind::Alert { gas: raw_call_result.gas_used.wrapping_sub(raw_call_result.stipend), outcome: outcome_kind };
 
         // Record logs, labels, traces and merge coverages.
         self.logs.extend(raw_call_result.logs);
@@ -525,6 +544,7 @@ impl TestResult {
     pub fn alert_fail(mut self, err: EvmError) -> Self {
         self.status = TestStatus::Failure;
         self.reason = Some(err.to_string());
+        self.kind = TestKind::Assertion { gas: 0, outcome: AssertionOutcomeKind::Revert };
         self
     }
 
@@ -653,7 +673,7 @@ impl fmt::Display for TestKindReport {
             Self::Unit { gas } => {
                 write!(f, "(gas: {gas})")
             }
-            Self::Alert { gas } => {
+            Self::Alert { gas, .. } => {
                 write!(f, "(gas: {gas})")
             }
             Self::Fuzz { runs, mean_gas, median_gas } => {
@@ -680,12 +700,21 @@ impl TestKindReport {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AssertionOutcomeKind {
+    Success,
+    Revert,
+    UnknownReturn,
+    Failure,
+}
+
 /// Various types of tests
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TestKind {
     /// An alert test result.
     Alert { 
         gas: u64,
+        outcome: AssertionOutcomeKind,
     },
     /// A unit test.
     Unit { gas: u64 },
@@ -711,7 +740,7 @@ impl TestKind {
     /// The gas consumed by this test
     pub fn report(&self) -> TestKindReport {
         match *self {
-            Self::Alert { gas } => TestKindReport::Unit { gas },
+            Self::Alert { gas, .. } => TestKindReport::Unit { gas },
             Self::Unit { gas } => TestKindReport::Unit { gas },
             Self::Fuzz { first_case: _, runs, mean_gas, median_gas } => {
                 TestKindReport::Fuzz { runs, mean_gas, median_gas }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use alloy_primitives::{Address, Log, U256};
 use eyre::Report;
-use forge_fmt::solang_ext::AstEq;
 use foundry_common::{evm::Breakpoints, get_contract_name, get_file_name, shell};
 use foundry_evm::{
     coverage::HitMaps,
@@ -18,7 +17,7 @@ use foundry_evm::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap}, fmt::{self, Write}, io::Read, time::Duration, u128
+    collections::{BTreeMap, HashMap}, fmt::{self, Write}, time::Duration,
 };
 use yansi::Paint;
 
@@ -506,20 +505,20 @@ impl TestResult {
             let bytes = output.into_data();
             match U256::try_from_be_slice(&bytes as &[u8]) {
                 None => {
-                    AssertionOutcomeKind::UnknownReturn
+                    AlertOutcomeKind::UnknownReturn
                 },
                 Some(val) => {
                     if val.leading_zeros() == 255 {
-                        AssertionOutcomeKind::Success
+                        AlertOutcomeKind::Success
                     } else if val.is_zero() {
-                        AssertionOutcomeKind::Failure
+                        AlertOutcomeKind::Failure
                     } else {
-                        AssertionOutcomeKind::UnknownReturn
+                        AlertOutcomeKind::UnknownReturn
                     }
                 }
             }
         } else {
-            AssertionOutcomeKind::UnknownReturn
+            AlertOutcomeKind::UnknownReturn
         };
 
         self.kind =
@@ -544,7 +543,7 @@ impl TestResult {
     pub fn alert_fail(mut self, err: EvmError) -> Self {
         self.status = TestStatus::Failure;
         self.reason = Some(err.to_string());
-        self.kind = TestKind::Assertion { gas: 0, outcome: AssertionOutcomeKind::Revert };
+        self.kind = TestKind::Alert { gas: 0, outcome: AlertOutcomeKind::Revert };
         self
     }
 
@@ -701,7 +700,7 @@ impl TestKindReport {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum AssertionOutcomeKind {
+pub enum AlertOutcomeKind {
     Success,
     Revert,
     UnknownReturn,
@@ -714,7 +713,7 @@ pub enum TestKind {
     /// An alert test result.
     Alert { 
         gas: u64,
-        outcome: AssertionOutcomeKind,
+        outcome: AlertOutcomeKind,
     },
     /// A unit test.
     Unit { gas: u64 },

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -400,7 +400,7 @@ impl<'a> ContractRunner<'a> {
                     TestFunctionKind::Alert => {
                         self.run_alert(func, setup)
                     }
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 };
 
                 res.duration = start.elapsed();


### PR DESCRIPTION
This change takes advantage of the new test variant in Phoundry and adds a new enum return type in the Assertio test outcome that better reflects the behavior Assertions represent (revert/success/failure vs success/failure). 

This change was tested manually.

## Motivation

## Solution
