### PR TITLE
feat: Add the ability to parse both boolean returns and returns with tuple for alert tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
+ "alloy-sol-types",
  "alloy-transport",
  "anvil",
  "async-trait",

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -404,8 +404,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            let block_number =
-                forking.block_number.map(u64::from).unwrap();
+            let block_number = forking.block_number.map(u64::from).unwrap();
             // reset the fork entirely and reapply the genesis config
             fork.reset(forking.json_rpc_url.clone(), block_number).await?;
             let fork_block_number = fork.block_number();

--- a/crates/evm/core/src/fork/backend.rs
+++ b/crates/evm/core/src/fork/backend.rs
@@ -214,7 +214,6 @@ where
         let block_number = self.block_number;
 
         let fut = Box::pin(async move {
-         
             let code = code_cache.get_code(&provider, address, chain, block_number);
             let balance = provider.get_balance(address).block_id(block_id).into_future();
             let nonce = provider.get_transaction_count(address).block_id(block_id).into_future();

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -68,6 +68,7 @@ alloy-serde.workspace = true
 alloy-signer.workspace = true
 alloy-sol-macro-expander = { workspace = true, features = ["json"] }
 alloy-sol-macro-input.workspace = true
+alloy-sol-types.workspace = true
 alloy-transport.workspace = true
 
 async-trait.workspace = true

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -308,7 +308,8 @@ impl<'a> ContractRunner<'a> {
         });
 
         // Invariant testing requires tracing to figure out what contracts were created.
-        let has_invariants = self.contract.abi.functions().any(|func| func.name.is_invariant_test());
+        let has_invariants =
+            self.contract.abi.functions().any(|func| func.name.is_invariant_test());
         let tmp_tracing =
             self.executor.inspector().tracer.is_none() && has_invariants && call_setup;
         if tmp_tracing {
@@ -397,9 +398,7 @@ impl<'a> ContractRunner<'a> {
                             identified_contracts.as_ref().unwrap(),
                         )
                     }
-                    TestFunctionKind::Alert => {
-                        self.run_alert(func, setup)
-                    }
+                    TestFunctionKind::Alert => self.run_alert(func, setup),
                     _ => unreachable!(),
                 };
 
@@ -454,11 +453,7 @@ impl<'a> ContractRunner<'a> {
     ///
     /// State modifications are not committed to the evm database but discarded after the call,
     /// similar to `eth_call`.
-    pub fn run_alert(
-        &self,
-        func: &Function,
-        setup: TestSetup,
-    ) -> TestResult {
+    pub fn run_alert(&self, func: &Function, setup: TestSetup) -> TestResult {
         let address = setup.address;
         let test_result = TestResult::new(setup);
 
@@ -477,8 +472,7 @@ impl<'a> ContractRunner<'a> {
             Err(err) => return test_result.alert_fail(err),
         };
 
-        let success = 
-            self.executor.is_raw_call_mut_success(address, &mut raw_call_result, false);
+        let success = self.executor.is_raw_call_mut_success(address, &mut raw_call_result, false);
         test_result.alert_result(success, reason, raw_call_result)
     }
 


### PR DESCRIPTION
This change allows alert tests to override notification messages. This is done by changing phoundry to be able to statically analyze new types of tuple returns, decode them, and then pass them to the monitor runner.

## Motivation


## Solution

