### PR TITLE
feat: Add separate setUp fn triggers to allow monitors to be created separately from normal runtime.

### DIFF
--- a/crates/evm/core/src/backend/code_cache.rs
+++ b/crates/evm/core/src/backend/code_cache.rs
@@ -150,7 +150,7 @@ fn test_cache_code() {
     let code = Bytes::new();
     let block_number = block_number - 10;
 
-    cache.cache_code(address, chain, block_number, code.clone());
+    cache.cache_code(address, chain, block_number, code);
     assert_eq!(
         cache.0.get(&(address, chain)).unwrap().no_code_detected_block_number,
         Some(block_number)

--- a/crates/evm/core/src/backend/data_access.rs
+++ b/crates/evm/core/src/backend/data_access.rs
@@ -147,7 +147,7 @@ mod test {
         let _ = db.basic_ref(weth).unwrap();
 
         let expected_access = Access {
-            access_type: AccessType::RevmDbAccess(RevmDbAccess::Basic(weth.clone())),
+            access_type: AccessType::RevmDbAccess(RevmDbAccess::Basic(weth)),
             chain: Chain::default(),
             state_lookup: StateLookup::RollN(0),
         };
@@ -161,7 +161,7 @@ mod test {
 
         let data_accesses = vec![
             Access {
-                access_type: AccessType::RevmDbAccess(RevmDbAccess::Basic(weth.clone())),
+                access_type: AccessType::RevmDbAccess(RevmDbAccess::Basic(weth)),
                 chain: Chain::default(),
                 state_lookup: StateLookup::RollN(0),
             },

--- a/crates/evm/core/src/backend/environment_cache.rs
+++ b/crates/evm/core/src/backend/environment_cache.rs
@@ -128,7 +128,7 @@ mod tests {
         let fork_url = fork_url();
         let good_provider = ProviderBuilder::new(&fork_url).build().unwrap();
 
-        let bad_provider = ProviderBuilder::new(&FAKE_FORK_URL).build().unwrap();
+        let bad_provider = ProviderBuilder::new(FAKE_FORK_URL).build().unwrap();
 
         let environment_cache = EnvironmentCache::default();
 
@@ -147,7 +147,7 @@ mod tests {
         let fork_url = fork_url();
         let good_provider = ProviderBuilder::new(&fork_url).build().unwrap();
 
-        let bad_provider = ProviderBuilder::new(&FAKE_FORK_URL).build().unwrap();
+        let bad_provider = ProviderBuilder::new(FAKE_FORK_URL).build().unwrap();
 
         let environment_cache = EnvironmentCache::default();
 
@@ -194,7 +194,7 @@ mod tests {
         let fork_url = fork_url();
         let good_provider = ProviderBuilder::new(&fork_url).build().unwrap();
 
-        let bad_provider = ProviderBuilder::new(&FAKE_FORK_URL).build().unwrap();
+        let bad_provider = ProviderBuilder::new(FAKE_FORK_URL).build().unwrap();
 
         let cache = EnvironmentCache::default();
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -503,6 +503,21 @@ impl TestResult {
         }
     }
 
+    /// Creates a failed test setup result.
+    pub fn setup_success(setup: TestSetup, duration: Duration) -> Self {
+        Self {
+            status: TestStatus::Success,
+            reason: setup.reason,
+            decoded_logs: decode_console_logs(&setup.logs),
+            logs: setup.logs,
+            traces: setup.traces,
+            coverage: setup.coverage,
+            labeled_addresses: setup.labeled_addresses,
+            duration,
+            ..Default::default()
+        }
+    }
+
     /// Returns the skipped result for single test (used in skipped fuzz and alert tests too).
     pub fn single_skip(mut self) -> Self {
         self.status = TestStatus::Skipped;

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -76,6 +76,14 @@ pub struct ContractRunner<'a> {
     pub span: tracing::Span,
 }
 
+/// Intermediate output of the setup function.
+pub struct SetupOutput {
+    pub setup: TestSetup,
+    pub warnings: Vec<String>,
+    pub call_after_invariant: bool,
+    pub has_invariants: bool,
+}
+
 impl<'a> ContractRunner<'a> {
     /// Deploys the test contract inside the runner from the sending account, and optionally runs
     /// the `setUp` function on the test contract.
@@ -101,6 +109,7 @@ impl<'a> ContractRunner<'a> {
 
         let mut logs = Vec::new();
         let mut traces = Vec::with_capacity(self.libs_to_deploy.len());
+        self.debug = true;
         for code in self.libs_to_deploy.iter() {
             match self.executor.deploy(
                 LIBRARY_DEPLOYER,
@@ -247,21 +256,16 @@ impl<'a> ContractRunner<'a> {
         }
         FuzzFixtures::new(fixtures)
     }
-
-    /// Runs all tests for a contract whose names match the provided regular expression
-    pub fn run_tests(
-        &mut self,
-        filter: &dyn TestFilter,
-        test_options: &TestOptions,
-        known_contracts: ContractsByArtifact,
-    ) -> SuiteResult {
-        let start = Instant::now();
+  
+    /// Runs just the setuo functions for the contract.
+    pub fn run_setups(&mut self, start: &Instant) -> Result<SetupOutput, SuiteResult> {
         let mut warnings = Vec::new();
 
         // Check if `setUp` function with valid signature declared.
         let setup_fns: Vec<_> =
             self.contract.abi.functions().filter(|func| func.name.is_setup()).collect();
         let call_setup = setup_fns.len() == 1 && setup_fns[0].name == "setUp";
+
         // There is a single miss-cased `setUp` function, so we add a warning
         for &setup_fn in setup_fns.iter() {
             if setup_fn.name != "setUp" {
@@ -273,12 +277,12 @@ impl<'a> ContractRunner<'a> {
         }
         // There are multiple setUp function, so we return a single test result for `setUp`
         if setup_fns.len() > 1 {
-            return SuiteResult::new(
+            return Err(SuiteResult::new(
                 start.elapsed(),
                 [("setUp()".to_string(), TestResult::fail("multiple setUp functions".to_string()))]
                     .into(),
                 warnings,
-            )
+            ))
         }
 
         // Check if `afterInvariant` function with valid signature declared.
@@ -286,7 +290,7 @@ impl<'a> ContractRunner<'a> {
             self.contract.abi.functions().filter(|func| func.name.is_after_invariant()).collect();
         if after_invariant_fns.len() > 1 {
             // Return a single test result failure if multiple functions declared.
-            return SuiteResult::new(
+            return Err(SuiteResult::new(
                 start.elapsed(),
                 [(
                     "afterInvariant()".to_string(),
@@ -294,7 +298,7 @@ impl<'a> ContractRunner<'a> {
                 )]
                 .into(),
                 warnings,
-            )
+            ))
         }
         let call_after_invariant = after_invariant_fns.first().map_or(false, |after_invariant_fn| {
             let match_sig = after_invariant_fn.name == "afterInvariant";
@@ -324,13 +328,39 @@ impl<'a> ContractRunner<'a> {
 
         if setup.reason.is_some() {
             // The setup failed, so we return a single test result for `setUp`
-            return SuiteResult::new(
+            return Err(SuiteResult::new(
                 start.elapsed(),
                 [("setUp()".to_string(), TestResult::setup_fail(setup))].into(),
                 warnings,
-            )
+            ))
         }
+        Ok(SetupOutput { setup, warnings, call_after_invariant, has_invariants })
+    }
 
+    pub fn run_only_setups(&mut self, start: &Instant) -> SuiteResult {
+        let setup_result = self.run_setups(start);
+        let output_suite = match setup_result {
+            Ok(output) => SuiteResult::new(start.elapsed(), BTreeMap::from_iter(vec![("setUp()".to_string(), TestResult::setup_success(output.setup, start.elapsed()))]), output.warnings),
+            Err(err) => err,
+        };
+        output_suite
+    }
+
+    /// Runs all tests for a contract whose names match the provided regular expression
+    pub fn run_tests(
+        &mut self,
+        filter: &dyn TestFilter,
+        test_options: &TestOptions,
+        known_contracts: ContractsByArtifact,
+    ) -> SuiteResult {
+        let start = Instant::now();
+
+        let SetupOutput { setup, warnings, call_after_invariant, has_invariants } = 
+        match self.run_setups(&start) {
+            Ok(setup) => setup,
+            Err(err) => return err,
+        };
+        
         // Filter out functions sequentially since it's very fast and there is no need to do it
         // in parallel.
         let find_timer = Instant::now();
@@ -467,9 +497,15 @@ impl<'a> ContractRunner<'a> {
             Some(self.revert_decoder),
         ) {
             Ok(res) => (res.raw, None),
-            Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
-            Err(EvmError::SkipError) => return test_result.single_skip(),
-            Err(err) => return test_result.alert_fail(err),
+            Err(EvmError::Execution(err)) => {
+                (err.raw, Some(err.reason))
+            }
+            Err(EvmError::SkipError) => {
+                return test_result.single_skip()
+            }
+            Err(err) => {
+                return test_result.alert_fail(err)
+            }
         };
 
         let success = self.executor.is_raw_call_mut_success(address, &mut raw_call_result, false);


### PR DESCRIPTION
This alters foundry to make it easy to trigger it running `setUp` functions by themselves. This allows us to both register anything we want at only setup time or runtime or both (such as for registering monitors), and transfer data from those results more easily.

## Motivation


## Solution
