### PR TITLE
feat: Add rollAt/rollBack cheatcodes, integrate statelookup access caching into existing fork cheatcodes

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6893,6 +6893,86 @@
     },
     {
       "func": {
+        "id": "rollForkAt_0",
+        "description": "Roll back to a specific block number in the active fork. A Phylax introduced cheatcode.",
+        "declaration": "function rollForkAt(uint256 blockNumber) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rollForkAt(uint256)",
+        "selector": "0x8d9fb99f",
+        "selectorBytes": [
+          141,
+          159,
+          185,
+          159
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "rollForkAt_1",
+        "description": "Roll back to a specific block number in the fork with the given ID. A Phylax introduced cheatcode.",
+        "declaration": "function rollForkAt(uint256 forkId, uint256 blockNumber) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rollForkAt(uint256,uint256)",
+        "selector": "0x03cb350e",
+        "selectorBytes": [
+          3,
+          203,
+          53,
+          14
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "rollForkBack_0",
+        "description": "Rolls back a certain number of blocks in the past, allowing for fast caching that results in faster testing runs. A Phylax introduced cheatcode.",
+        "declaration": "function rollForkBack(uint256 blocksInThePast) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rollForkBack(uint256)",
+        "selector": "0x9a273b72",
+        "selectorBytes": [
+          154,
+          39,
+          59,
+          114
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "rollForkBack_1",
+        "description": "Rolls back a certain number of blocks in the past in the fork with the given ID, allowing for fast caching that results in faster testing runs. A Phylax introduced cheatcode.",
+        "declaration": "function rollForkBack(uint256 forkId, uint256 blocksInThePast) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rollForkBack(uint256,uint256)",
+        "selector": "0xa3e5c910",
+        "selectorBytes": [
+          163,
+          229,
+          201,
+          16
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "rollFork_0",
         "description": "Updates the currently active fork to given block number\nThis is similar to `roll` but for the currently active fork.",
         "declaration": "function rollFork(uint256 blockNumber) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -600,6 +600,19 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function selectFork(uint256 forkId) external;
 
+    /// Roll back to a specific block number in the active fork. A Phylax introduced cheatcode.
+    #[cheatcode(group = Evm, safety = Unsafe)] 
+    function rollForkAt(uint256 blockNumber) external;
+    /// Roll back to a specific block number in the fork with the given ID. A Phylax introduced cheatcode.
+    #[cheatcode(group = Evm, safety = Unsafe)] 
+	function rollForkAt(uint256 forkId, uint256 blockNumber) external;
+    /// Rolls back a certain number of blocks in the past, allowing for fast caching that results in faster testing runs. A Phylax introduced cheatcode.
+    #[cheatcode(group = Evm, safety = Unsafe)] 
+	function rollForkBack(uint256 blocksInThePast) external;
+    /// Rolls back a certain number of blocks in the past in the fork with the given ID, allowing for fast caching that results in faster testing runs. A Phylax introduced cheatcode.
+    #[cheatcode(group = Evm, safety = Unsafe)] 
+	function rollForkBack(uint256 forkId, uint256 blocksInThePast) external;
+
     /// Fetches the given transaction from the active fork and executes it on the current state.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function transact(bytes32 txHash) external;

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -4,7 +4,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
-use foundry_evm_core::fork::CreateFork;
+use foundry_evm_core::{backend::StateLookup, fork::CreateFork};
 
 impl Cheatcode for activeForkCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
@@ -66,6 +66,7 @@ impl Cheatcode for rollFork_0Call {
         ccx.ecx.db.roll_fork(
             None,
             (*blockNumber).to(),
+            StateLookup::RollN(0),
             &mut ccx.ecx.env,
             &mut ccx.ecx.journaled_state,
         )?;
@@ -94,6 +95,7 @@ impl Cheatcode for rollFork_2Call {
         ccx.ecx.db.roll_fork(
             Some(*forkId),
             (*blockNumber).to(),
+            StateLookup::RollN(0),
             &mut ccx.ecx.env,
             &mut ccx.ecx.journaled_state,
         )?;
@@ -114,6 +116,66 @@ impl Cheatcode for rollFork_3Call {
         Ok(Default::default())
     }
 }
+
+impl Cheatcode for rollForkAt_0Call {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { blockNumber } = self;
+        println!("roll fork at 0 call");
+        persist_caller(ccx);
+        let maybe_current_fork_id = ccx.ecx.db.active_fork_id();
+        ccx.ecx.db.roll_fork_at(
+            maybe_current_fork_id,
+            (*blockNumber).to(),
+            &mut ccx.ecx.env,
+            &mut ccx.ecx.journaled_state,
+        )?;
+        Ok(Default::default())
+    }
+}
+
+impl Cheatcode for rollForkAt_1Call {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { forkId, blockNumber } = self;
+        persist_caller(ccx);
+        ccx.ecx.db.roll_fork_at(
+            Some(*forkId),
+            (*blockNumber).to(),
+            &mut ccx.ecx.env,
+            &mut ccx.ecx.journaled_state,
+        )?;
+        Ok(Default::default())
+    }
+}
+
+impl Cheatcode for rollForkBack_0Call {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { blocksInThePast } = self;
+        persist_caller(ccx);
+        let maybe_current_fork_id = ccx.ecx.db.active_fork_id();
+        ccx.ecx.db.roll_fork_back(
+            maybe_current_fork_id,
+            (*blocksInThePast).to(),
+            &mut ccx.ecx.env,
+            &mut ccx.ecx.journaled_state,
+        )?;
+        Ok(Default::default())
+    }
+}
+
+impl Cheatcode for rollForkBack_1Call {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { forkId, blocksInThePast } = self;
+        persist_caller(ccx);
+        ccx.ecx.db.roll_fork_back(
+            Some(*forkId),
+            (*blocksInThePast).to(),
+            &mut ccx.ecx.env,
+            &mut ccx.ecx.journaled_state,
+        )?;
+        Ok(Default::default())
+    }
+}
+
 
 impl Cheatcode for selectForkCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -54,7 +54,7 @@ pub fn abi_decode_calldata(
         calldata = &calldata[4..];
     }
 
-    let res = if input {
+    let res: Vec<DynSolValue> = if input {
         func.abi_decode_input(calldata, false)
     } else {
         func.abi_decode_output(calldata, false)

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -21,6 +21,8 @@ use revm::{
 };
 use std::{borrow::Cow, collections::BTreeMap};
 
+use super::StateLookup;
+
 /// A wrapper around `Backend` that ensures only `revm::DatabaseRef` functions are called.
 ///
 /// Any changes made during its existence that affect the caching layer of the underlying Database
@@ -162,10 +164,11 @@ impl<'a> DatabaseExt for CowBackend<'a> {
         &mut self,
         id: Option<LocalForkId>,
         block_number: u64,
+        state_lookup: StateLookup,  
         env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        self.backend_mut(env).roll_fork(id, block_number, env, journaled_state)
+        self.backend_mut(env).roll_fork(id, block_number, state_lookup, env, journaled_state)
     }
 
     fn roll_fork_to_transaction(
@@ -176,6 +179,26 @@ impl<'a> DatabaseExt for CowBackend<'a> {
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         self.backend_mut(env).roll_fork_to_transaction(id, transaction, env, journaled_state)
+    }
+
+    fn roll_fork_at(
+        &mut self,
+        id: Option<LocalForkId>,
+        block_number: u64,
+        env: &mut Env,
+        journaled_state: &mut JournaledState,
+    ) -> eyre::Result<()> {
+        self.backend_mut(env).roll_fork_at(id, block_number, env, journaled_state)
+    }
+
+    fn roll_fork_back(
+        &mut self,
+        id: Option<LocalForkId>,
+        roll_back_block_count: i64,
+        env: &mut Env,
+        journaled_state: &mut JournaledState,
+    ) -> eyre::Result<()> {
+        self.backend_mut(env).roll_fork_back(id, roll_back_block_count, env, journaled_state)
     }
 
     fn transact<I: InspectorExt<Backend>>(

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -139,8 +139,8 @@ impl<'a> DatabaseExt for CowBackend<'a> {
         }
     }
 
-    fn create_fork(&mut self, fork: CreateFork) -> eyre::Result<LocalForkId> {
-        self.backend.to_mut().create_fork(fork)
+    fn create_fork(&mut self, fork: CreateFork, state_lookup: StateLookup) -> eyre::Result<LocalForkId> {
+        self.backend.to_mut().create_fork(fork, state_lookup)
     }
 
     fn create_fork_at_transaction(

--- a/crates/evm/core/src/backend/data_access.rs
+++ b/crates/evm/core/src/backend/data_access.rs
@@ -130,7 +130,7 @@ mod test {
             evm_opts: EvmOpts { fork_block_number: Some(1), ..Default::default() },
         };
 
-        db.create_fork(create_fork).unwrap();
+        db.create_fork(create_fork, StateLookup::RollAt(1)).unwrap();
 
         db.data_accesses.contains(&Access {
             access_type: AccessType::CreateFork(ENDPOINT.to_string()),

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1347,11 +1347,7 @@ impl DatabaseExt for Backend {
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "roll fork at block");
         let id = self.ensure_fork(id)?;
-
         self.roll_fork(Some(id), block_number, StateLookup::RollAt(block_number), env, journaled_state)?;
-        let active_fork_url = self.active_fork_url().unwrap();
-        let accesses = self.get_accesses();
-        self.load_accesses(&accesses, env.cfg.chain_id.into(), block_number, active_fork_url.clone())?;
         Ok(())
     }
 
@@ -1364,12 +1360,9 @@ impl DatabaseExt for Backend {
     ) -> eyre::Result<()> {
         let id = self.ensure_fork(id)?;
         let fork_id = self.ensure_fork_id(id)?;
-        let active_fork_url = self.forks.get_fork_url(fork_id.clone())?.unwrap();
         let block_number: u64 = env.block.number.to();
         trace!(?id, ?roll_back_block_count, ?fork_id, current_block=?env.block.number, "roll fork back by N blocks");
         self.roll_fork(Some(id), block_number, StateLookup::RollN(roll_back_block_count), env, journaled_state)?;
-        let accesses = self.get_accesses();
-        self.load_accesses(&accesses, env.cfg.chain_id.into(), block_number, active_fork_url)?;
         Ok(())
     }
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -204,10 +204,9 @@ pub trait DatabaseExt: Database<Error = DatabaseError> {
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
-    /// Updates the fork to given transaction hash
+    /// Updates the fork to a specific block number, and optimistically loads storage from previous blocks if they are cached. A Phylax introduced cheatcode.
     ///
-    /// This will essentially create a new fork at the block this transaction was mined and replays
-    /// all transactions up until the given transaction.
+    /// This will create a new fork at the block and attempts to load cached storage from previous blocks.
     ///
     /// # Errors
     ///
@@ -220,10 +219,9 @@ pub trait DatabaseExt: Database<Error = DatabaseError> {
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()>;
 
-    /// Updates the fork to given transaction hash
+    /// Updates the fork to the N number of blocks before the current block, and optimistically loads storage from those previous blocks. A Phylax introduced cheatcode.
     ///
-    /// This will essentially create a new fork at the block this transaction was mined and replays
-    /// all transactions up until the given transaction.
+    /// This will create a new fork at the block N numbers from the current block on the forkand attempts to load cached storage from previous blocks.
     ///
     /// # Errors
     ///

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -340,6 +340,10 @@ interface Vm {
     function revokePersistent(address account) external;
     function revokePersistent(address[] calldata accounts) external;
     function roll(uint256 newHeight) external;
+    function rollForkAt(uint256 blockNumber) external;
+    function rollForkAt(uint256 forkId, uint256 blockNumber) external;
+    function rollForkBack(uint256 blocksInThePast) external;
+    function rollForkBack(uint256 forkId, uint256 blocksInThePast) external;
     function rollFork(uint256 blockNumber) external;
     function rollFork(bytes32 txHash) external;
     function rollFork(uint256 forkId, uint256 blockNumber) external;


### PR DESCRIPTION
This change threads the statelookup associated with access caching behavior for rollAt/rollBack cheatcodes and adds functionality to allow some createFork cheatcodes to also take advantage of statelookup data access caching. 

## Motivation

## Solution

