### PR TITLE
feat: Add createfork chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,6 +3627,7 @@ dependencies = [
 name = "foundry-cheatcodes"
 version = "0.2.0"
 dependencies = [
+ "alloy-chains",
  "alloy-dyn-abi",
  "alloy-genesis",
  "alloy-json-abi",

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -30,6 +30,7 @@ alloy-sol-types.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-types.workspace = true
 alloy-signer.workspace = true
+alloy-chains.workspace = true
 alloy-signer-local = { workspace = true, features = [
     "mnemonic-all-languages",
     "keystore",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3373,6 +3373,46 @@
     },
     {
       "func": {
+        "id": "createFork_3",
+        "description": "Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork.",
+        "declaration": "function createFork(uint256 chainId) external returns (uint256 forkId);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createFork(uint256)",
+        "selector": "0x68b89f2b",
+        "selectorBytes": [
+          104,
+          184,
+          159,
+          43
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "createFork_4",
+        "description": "Creates a new fork with the given endpoint and block and returns the identifier of the fork.",
+        "declaration": "function createFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createFork(uint256,uint256)",
+        "selector": "0xb2ef12d0",
+        "selectorBytes": [
+          178,
+          239,
+          18,
+          208
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "createSelectFork_0",
         "description": "Creates and also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork.",
         "declaration": "function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);",
@@ -3425,6 +3465,46 @@
           213,
           43,
           122
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "createSelectFork_3",
+        "description": "Creates and also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork.",
+        "declaration": "function createSelectFork(uint256 chainId) external returns (uint256 forkId);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createSelectFork(uint256)",
+        "selector": "0x07b8c65e",
+        "selectorBytes": [
+          7,
+          184,
+          198,
+          94
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "createSelectFork_4",
+        "description": "Creates and also selects a new fork with the given endpoint and block and returns the identifier of the fork.",
+        "declaration": "function createSelectFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "createSelectFork(uint256,uint256)",
+        "selector": "0x027f8b84",
+        "selectorBytes": [
+          2,
+          127,
+          139,
+          132
         ]
       },
       "group": "evm",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -570,6 +570,14 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function createFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
 
+    /// Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function createFork(uint256 chainId) external returns (uint256 forkId);
+    /// Creates a new fork with the given endpoint and block and returns the identifier of the fork.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function createFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);
+
+
     /// Creates and also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);
@@ -580,6 +588,12 @@ interface Vm {
     /// replays all transaction mined in the block before the transaction, returns the identifier of the fork.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function createSelectFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
+    /// Creates and also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function createSelectFork(uint256 chainId) external returns (uint256 forkId);
+    /// Creates and also selects a new fork with the given endpoint and block and returns the identifier of the fork.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function createSelectFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);
 
     /// Updates the currently active fork to given block number
     /// This is similar to `roll` but for the currently active fork.

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -1,5 +1,6 @@
 use super::Result;
 use crate::{script::ScriptWallets, Vm::Rpc};
+use alloy_chains::Chain;
 use alloy_primitives::Address;
 use foundry_common::{fs::normalize_path, ContractsByArtifact};
 use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
@@ -52,6 +53,8 @@ pub struct CheatsConfig {
     pub available_artifacts: Option<ContractsByArtifact>,
     /// Version of the script/test contract which is currently running.
     pub running_version: Option<Version>,
+    /// If provided, restricts the number of chains the CreateFork and related cheatcodes may switch to.
+    pub valid_chains_by_url: Option<HashMap<Chain, String>>,
 }
 
 impl CheatsConfig {
@@ -90,6 +93,7 @@ impl CheatsConfig {
             script_wallets,
             available_artifacts,
             running_version,
+            valid_chains_by_url: None,
         }
     }
 
@@ -217,6 +221,7 @@ impl Default for CheatsConfig {
             script_wallets: None,
             available_artifacts: Default::default(),
             running_version: Default::default(),
+            valid_chains_by_url: None,
         }
     }
 }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -164,9 +164,13 @@ interface Vm {
     function createFork(string calldata urlOrAlias) external returns (uint256 forkId);
     function createFork(string calldata urlOrAlias, uint256 blockNumber) external returns (uint256 forkId);
     function createFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
+    function createFork(uint256 chainId) external returns (uint256 forkId);
+    function createFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);
     function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);
     function createSelectFork(string calldata urlOrAlias, uint256 blockNumber) external returns (uint256 forkId);
     function createSelectFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
+    function createSelectFork(uint256 chainId) external returns (uint256 forkId);
+    function createSelectFork(uint256 chainId, uint256 blockNumber) external returns (uint256 forkId);
     function createWallet(string calldata walletLabel) external returns (Wallet memory wallet);
     function createWallet(uint256 privateKey) external returns (Wallet memory wallet);
     function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);


### PR DESCRIPTION
This change adds a map of the chain-id's and their specified URLs to the cheatcode config that is instantiated on every execution of the PhylaxRunner, as well as the chainId specific createSelectFork and createFork cheatcodes.

## Motivation


## Solution

