### PR TITLE
chore: remove warning

### DIFF
--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -50,14 +50,6 @@ impl GlobalArgs {
             self.force_init_thread_pool()?;
         }
 
-        // Display a warning message if the current version is not stable.
-        if std::env::var("FOUNDRY_DISABLE_NIGHTLY_WARNING").is_err() &&
-            !self.json &&
-            IS_NIGHTLY_VERSION
-        {
-            let _ = sh_warn!("{}", NIGHTLY_VERSION_WARNING_MESSAGE);
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
Remove the nightly error. Realistically for the time being we are going to lag behind in terms of versioning.